### PR TITLE
Add support for pylibmc

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,6 +61,10 @@ is planned to be released under a BSD like licence in future.
 Changes
 -------
 
+  * 1.2.0 (unreleased)
+      * Change to use pylibmc when available
+      * Add option to require with bda.cache[pylibmc]
+
   * 1.1.2 (rnix, 2009-02-10)
       * remove legacy code
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(name='bda.cache',
           'zope.component',
       ],
       extras_require={
+          'pylibmc': [
+              'pylibmc'
+           ],
           'test': [
               'interlude',
               'zope.testing',

--- a/src/bda/cache/memcached.py
+++ b/src/bda/cache/memcached.py
@@ -15,8 +15,11 @@ from interfaces import CacheException
 from interfaces import IMemcachedProvider
 try:
     from pylibmc import Client
+    import zlib
+    PYLIBMC = True
 except ImportError:
     from memcache import Client
+    PYLIBMC = False
 
 class MemcachedException(CacheException): pass
 
@@ -61,8 +64,13 @@ class Memcached(object):
         return self._client.get(key)
     
     def __setitem__(self, key, object):
-        self._client.set(key, object, time=self.timeout)
-    
+        if PYLIBMC:
+            self._client.set(key, object, time=self.timeout,
+                             min_compress_len=1024000,
+                             compress_level=zlib.Z_BEST_SPEED)
+        else:
+            self._client.set(key, object, time=self.timeout)
+
     def __delitem__(self, key):
         self._client.delete(key)
 

--- a/src/bda/cache/memcached.py
+++ b/src/bda/cache/memcached.py
@@ -13,7 +13,10 @@ from interfaces import ICacheManager
 from interfaces import ICacheProvider
 from interfaces import CacheException
 from interfaces import IMemcachedProvider
-from memcache import Client 
+try:
+    from pylibmc import Client
+except ImportError:
+    from memcache import Client
 
 class MemcachedException(CacheException): pass
 


### PR DESCRIPTION
After Zope profiler told me that pas.plugins.ldap spent most of its time with pickle and memcached, I thought, it would be a good idea to use C-optimized calls for those (pylibmc uses libmemcached and cPickle).
