### PR TITLE
Add support for libmc

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -62,8 +62,8 @@ Changes
 -------
 
   * 1.2.0 (unreleased)
-      * Change to use pylibmc when available
-      * Add option to require with bda.cache[pylibmc]
+      * Change to use libmc or pylibmc when available
+      * Add option to require with bda.cache[pylibmc] or bda.cache[libmc]
 
   * 1.1.2 (rnix, 2009-02-10)
       * remove legacy code

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(name='bda.cache',
           'zope.component',
       ],
       extras_require={
+          'libmc': [
+              'libmc'
+           ],
           'pylibmc': [
               'pylibmc'
            ],


### PR DESCRIPTION
Maybe this is getting too complex, but just want to notify about our current version.

Once we got more active logged-in users with pas.plugins.ldap, we started getting various random libmemcached errors with pylibmc, which only got resolved by restarting the Plone instance in question. Now we are using libmc: https://github.com/douban/libmc

Looking good so far.